### PR TITLE
Feature/webpack3 support

### DIFF
--- a/mobius/templatetags/mobius_tags.py
+++ b/mobius/templatetags/mobius_tags.py
@@ -12,9 +12,13 @@ except ImportError:
     from webpack_loader.templatetags.webpack_loader import _get_bundle
 
 try:
+    # webpack_loader 0.5.0
     from webpack_loader.exceptions import WebpackBundleLookupError
 except ImportError:
-    class WebpackBundleLookupError(object):
+    # webpack_loader 0.3.3
+    # FIXME: jw&phala, @hedley we dont know how to do this cleaner.
+    # TODO: this is here for backwards compatibility
+    class WebpackBundleLookupError(Exception):
         pass
 
 
@@ -60,7 +64,7 @@ class IfHasBundleNode(template.Node):
         try:
             _get_bundle(bundle_name, extension, config)
             return self.nodelist.render(context)
-        except KeyError, WebpackBundleLookupError:
+        except (KeyError, WebpackBundleLookupError):
             return ""
 
 

--- a/mobius/templatetags/mobius_tags.py
+++ b/mobius/templatetags/mobius_tags.py
@@ -4,7 +4,13 @@ from django import template
 from django.core.urlresolvers import resolve, get_script_prefix
 from django.http import HttpResponse
 
-from webpack_loader.templatetags.webpack_loader import _get_bundle
+try:
+    # webpack_loader 0.5.0
+    from webpack_loader.utils import _get_bundle
+    from webpack_loader import exceptions
+except ImportError:
+    # webpack_loader 0.3.3
+    from webpack_loader.templatetags.webpack_loader import _get_bundle
 
 
 register = template.Library()
@@ -49,8 +55,9 @@ class IfHasBundleNode(template.Node):
         try:
             _get_bundle(bundle_name, extension, config)
             return self.nodelist.render(context)
-        except KeyError:
+        except KeyError, exceptions.WebpackBundleLookupError:
             return ""
+
 
 
 @register.tag

--- a/mobius/templatetags/mobius_tags.py
+++ b/mobius/templatetags/mobius_tags.py
@@ -7,10 +7,15 @@ from django.http import HttpResponse
 try:
     # webpack_loader 0.5.0
     from webpack_loader.utils import _get_bundle
-    from webpack_loader import exceptions
 except ImportError:
     # webpack_loader 0.3.3
     from webpack_loader.templatetags.webpack_loader import _get_bundle
+
+try:
+    from webpack_loader.exceptions import WebpackBundleLookupError
+except ImportError:
+    class WebpackBundleLookupError(object):
+        pass
 
 
 register = template.Library()
@@ -55,7 +60,7 @@ class IfHasBundleNode(template.Node):
         try:
             _get_bundle(bundle_name, extension, config)
             return self.nodelist.render(context)
-        except KeyError, exceptions.WebpackBundleLookupError:
+        except KeyError, WebpackBundleLookupError:
             return ""
 
 


### PR DESCRIPTION
update to support [django-webpack-loader](https://github.com/ezhome/django-webpack-loader) 0.5.0
We redefined one of the exception classes that are thrown in  0.5.0 to make the code backwards compatible.

But it's ugly. Please take a look and let us know if there is a cleaner way.